### PR TITLE
Remove JS Way homework

### DIFF
--- a/lesson-1.md
+++ b/lesson-1.md
@@ -118,3 +118,14 @@ Here is a list of topic ideas which you could present about:
 - Why is the "Conditional" block useful?
 
 If you want to present a different idea, that is fine as well. Then next week, you'll each present what you learned to a few students from the class.
+
+### Write an "algorithm recipe"
+
+Programming is all about writing *algorithms*. What is an algorithm?
+
+1. Read this [section of a book](https://github.com/thejsway/thejsway/blob/master/manuscript/intro02.md#introduction-to-algorithms)
+1. Watch [this video](http://youtube.com/watch?v=cDA3_5982h8) 😄
+
+These show "algorithm recipes", and the video shows that you have to think carefully when writing them!
+
+Write your own "algorithm recipe" for your favourite food and submit it to Google Classroom. Next week we'll read some of the best algorithms to see if they have any missing steps!

--- a/lesson-2.md
+++ b/lesson-2.md
@@ -18,6 +18,10 @@ Problem solving is a critical skill for programmers, including for experts. Ofte
 
 To help develop your problem solving skills, we'll play a fun game in small groups. Followed by a short [presentation](https://docs.google.com/presentation/d/1XzLUVxfiJE2llWTWn7Rf5T0cutcL9HCBwd09GBCzv_4/) about improving your problem solving.
 
+## "Algorithm recipe" review
+
+Last week you should have written a "algorithm recipe". The instructor will pick out a few of the best to read with the rest of the class. We'll see if there are any missing steps!
+
 ## Homework presentation
 
 For last week's homework, you will have made a presentation about something you learned in the last week. Now is your chance to present it! We'll break into groups of 3 - 4 and take turns to present to the rest of your group for **5 minutes**.
@@ -30,7 +34,7 @@ Remember that communicating information to others is a really important skill fo
 * Try to make it fun!
 * Stick to the time. The volunteer will cut you off at 5 minutes!
 
-## Homework in perspective - how is it applicable? 
+## Homework in perspective - how is it applicable?
 
 Although the block-based coding you practiced for homework solved only simple problems with a simple language, we'll look briefly at four concepts you used which are also at the heart of professional coding.
 
@@ -67,15 +71,3 @@ There will be some time in class to start the first exercises. Let the instructo
 #### No headphones? Read the subtitles or video transcript
 
 If you do not have headphones to watch the videos you can click on "CC" (subtitles/closed captions) in the video window, or underneath the video on "Transcript".
-
-### The JS Way: Welcome to programming chapter
-
-[The JS Way](https://github.com/bpesquet/thejsway) is a book that is available to read online for free. It is a beginner-friendly introduction to the JavaScript programming language.
-
-[Click here](https://github.com/bpesquet/thejsway/blob/master/manuscript/intro02.md) to read the "Welcome to programming" chapter.
-
-### Write an "algorithm recipe"
-
-Once you've read The JS Way chapter above, you'll see that there is a section about writing algorithms. In the chapter is there is an example of a burrito "algorithm recipe". You might also want to watch [this video](http://youtube.com/watch?v=cDA3_5982h8) which also has some "algorithm recipes" 😄. Think like the Dad when writing yours!
-
-Write your own "algorithm recipe" for your favourite food. Make sure you submit it to Google Classroom.

--- a/lesson-3.md
+++ b/lesson-3.md
@@ -116,14 +116,3 @@ Each student will have a pairing session with one of the instructors to solve a 
 Make sure you understand the homework for next week before you leave the classroom. See Google Classroom for the definitive list of homework assignments. Make sure you check it regularly.
 
 <!-- TODO: Make sure the homework is all here -->
-
-### The JS Way
-
-We're going to read more of [The JS Way](https://github.com/bpesquet/thejsway) book. The chapters that we want to read are:
-
-1. [Environment setup](https://github.com/bpesquet/thejsway/blob/master/manuscript/intro04.md) (note: **please use Solution A**)
-2. [Chapter 1: 3, 2, 1... Code!](https://github.com/bpesquet/thejsway/blob/master/manuscript/chapter01.md)
-3. [Chapter 2: Play with variables](https://github.com/bpesquet/thejsway/blob/master/manuscript/chapter02.md)
-4. [Chapter 3: Add conditions](https://github.com/bpesquet/thejsway/blob/master/manuscript/chapter03.md)
-5. [Chapter 4: Repeat statements](https://github.com/bpesquet/thejsway/blob/master/manuscript/chapter04.md)
-6. [Chapter 5: Write functions](https://github.com/bpesquet/thejsway/blob/master/manuscript/chapter05.md)


### PR DESCRIPTION
Removes JS Way book from the homework.

Only slightly controversial bit is that the "algorithm recipe" homework that we set (but didn't really follow up on) depended on reading about this idea in the JS Way intro.

So instead, I've kept the link to the JS Way "algorithm recipe" section and added a section to the following lesson to read through some of the best in class (and try poke holes in them). I also felt that lesson 3 already had quite a bit of stuff in it, and lesson 2 was a bit light, so I've moved it forward to be set during the first week of homework.

Any thoughts on this? I'm happy to drop entirely if you don't think it's worth it.